### PR TITLE
panic on failure for sslocal

### DIFF
--- a/src/bin/local.rs
+++ b/src/bin/local.rs
@@ -231,4 +231,5 @@ fn main() {
     }
 
     RelayLocal::new(config).run(threads);
+    panic!("Relay stopped.");
 }


### PR DESCRIPTION
systemd 之类的程序需要在失败时返回表示失败的状态码。