### PR TITLE
Increase the default stack size from 64K to 128K

### DIFF
--- a/src/bin/local.rs
+++ b/src/bin/local.rs
@@ -296,7 +296,7 @@ fn main() {
 
     Scheduler::new()
         .with_workers(threads)
-        .default_stack_size(64 * 1024)
+        .default_stack_size(128 * 1024)
         .run(move || {
             RelayLocal::new(config).run();
         })

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -277,7 +277,7 @@ fn main() {
 
     Scheduler::new()
         .with_workers(threads)
-        .default_stack_size(64 * 1024)
+        .default_stack_size(128 * 1024)
         .run(move || {
             RelayServer::new(config).run();
         })


### PR DESCRIPTION
This pull request fixes a regression initially described in Issue #19 and fixed in c5822d9ab5740414d317da95f1fe6d75c92ab3c4 by increasing the default stack size to 128K. The bug was reintroduced in cff29c3f226183a0963eb4d7a358423433f72ca5, where ``COROUTINE_STACK_SIZE`` was removed from [src/relay/mod.rs](https://github.com/zonyitoo/shadowsocks-rust/commit/cff29c3f226183a0963eb4d7a358423433f72ca5#diff-c8cd9e7fad78336b2736f91937ce4102L40) and ``default_stack_size`` was set to 64K in [src/bin/local.rs](https://github.com/zonyitoo/shadowsocks-rust/commit/cff29c3f226183a0963eb4d7a358423433f72ca5#diff-bff3171e8f58772ecdd6d044b736927eR278) and [src/bin/local.rs](https://github.com/zonyitoo/shadowsocks-rust/commit/cff29c3f226183a0963eb4d7a358423433f72ca5#diff-c110e1433afdc14adcd9cda130d53415R258).
