### PR TITLE
Update dependency ``byteorder`` from 0.3.x to 0.5.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ path = "src/bin/ssurl.rs"
 [dependencies]
 rustc-serialize = "^0.3.15"
 log = "^0.3.1"
-byteorder = "^0.3.11"
+byteorder = "^0.5.0"
 rand = "^0.3.9"
 time = "^0.1.32"
 clap = "^1.1.6"


### PR DESCRIPTION
The rationale of this pull request is similar to that of [pull request #40](https://github.com/BurntSushi/byteorder/pull/40) of ``byteorder``. Before ``byteorder`` 0.5.x, we need to handle two (syntactically) different yet (conceptually) equivalent versions of errors (i.e., ``std::io::Error`` and ``byteorder::Error``). With ``byteorder`` 0.5.x, we can write much neater code.